### PR TITLE
Allow terraform to store remote state

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -1,3 +1,9 @@
+terraform {
+  backend "s3" {
+    region = "eu-west-1"
+  }
+}
+
 provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"


### PR DESCRIPTION
This module it not currently setup to store remote state when run directly.

Adding the s3 backend config allows this.