### PR TITLE
Expand iam role to keys file

### DIFF
--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -168,8 +168,7 @@ data "aws_iam_policy_document" "survey_runner_task" {
     ]
 
     "resources" = [
-      "arn:aws:s3:::${var.s3_secrets_bucket}",
-      "arn:aws:s3:::${var.s3_secrets_bucket}/${var.secrets_file_name}",
+      "arn:aws:s3:::${var.s3_secrets_bucket}*"
     ]
   }
 }


### PR DESCRIPTION
The IAM roles was not updated to include the new keys.yml file in S3

The PR opens up the IAM role to allow survey runner to retrieve its keys file from S3