### PR TITLE
Use Built-in AWS Role for ECS scaling

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -25,9 +25,9 @@ data "aws_alb_listener" "eq" {
 }
 
 data "aws_alb" "eq" {
-  arn  = "${data.aws_alb_listener.eq.load_balancer_arn}"
+  arn = "${data.aws_alb_listener.eq.load_balancer_arn}"
 }
 
 data "aws_route53_zone" "dns_zone" {
-  name         = "${var.dns_zone_name}"
+  name = "${var.dns_zone_name}"
 }

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "survey_runner_task" {
     ]
 
     "resources" = [
-      "arn:aws:s3:::${var.s3_secrets_bucket}*"
+      "arn:aws:s3:::${var.s3_secrets_bucket}*",
     ]
   }
 
@@ -186,7 +186,7 @@ data "aws_iam_policy_document" "survey_runner_task" {
     ]
 
     "resources" = [
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.submitted_responses_table_name}"
+      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.submitted_responses_table_name}",
     ]
   }
 }


### PR DESCRIPTION
This change stops us getting the error with `module.survey-runner-on-ecs.aws_iam_role.survey_runner_scaling` when running `terraform destroy`

This has been done by using a built in AWS role (`AWSServiceRoleForApplicationAutoScaling_ECSService `) which gives us the permissions we need.

To test
In `eq-terraform` include this module by changing `survey-runner.tf` line 63 to
`source                         = "github.com/ONSdigital/eq-survey-runner-deploy?ref=fix-ecs-scaling"`

then run `terraform apply`

after creation then run `terraform destroy` you should not get the iam error while destroying

*Note* - You may still get the internet gateway error.
