### PR TITLE
Allow New Relic to be enabled for container

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -109,3 +109,19 @@ variable "respondent_account_url" {
 variable "submitted_responses_table_name" {
   description = "Table name of table used for storing Submitted Responses"
 }
+
+# New Relic
+variable "new_relic_enabled" {
+  description = "Enable NewRelic monitoring"
+  default     = false
+}
+
+variable "new_relic_app_name" {
+  description = "NewRelic App Name"
+  default     = "Survey Runner"
+}
+
+variable "new_relic_licence_key" {
+  description = "NewRelic Licence Key"
+  default     = ""
+}

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -61,6 +61,10 @@ data "template_file" "survey_runner" {
     CONTAINER_TAG                        = "${var.survey_runner_tag}"
     RESPONDENT_ACCOUNT_URL               = "${var.respondent_account_url}"
     EQ_SUBMITTED_RESPONSES_TABLE_NAME    = "${var.submitted_responses_table_name}"
+    EQ_NEW_RELIC_ENABLED                 = "${var.new_relic_enabled}"
+    NEW_RELIC_LICENSE_KEY                = "${var.new_relic_licence_key}"
+    NEW_RELIC_APP_NAME                   = "${var.new_relic_app_name}"
+
   }
 }
 

--- a/task-definitions/survey-runner.json
+++ b/task-definitions/survey-runner.json
@@ -66,6 +66,18 @@
       {
         "name": "EQ_SUBMITTED_RESPONSES_TABLE_NAME",
         "value": "${EQ_SUBMITTED_RESPONSES_TABLE_NAME}"
+      },
+      {
+        "name": "EQ_NEW_RELIC_ENABLED",
+        "value": "${EQ_NEW_RELIC_ENABLED}"
+      },
+      {
+        "name": "NEW_RELIC_LICENSE_KEY",
+        "value": "${NEW_RELIC_LICENSE_KEY}"
+      },
+      {
+        "name": "NEW_RELIC_APP_NAME",
+        "value": "${NEW_RELIC_APP_NAME}"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
This just allows us to pass in the New Relic environment variables to the Survey Runner container