### PR TITLE
Fix NewRelic default flag

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -113,7 +113,7 @@ variable "submitted_responses_table_name" {
 # New Relic
 variable "new_relic_enabled" {
   description = "Enable NewRelic monitoring"
-  default     = false
+  default     = "False"
 }
 
 variable "new_relic_app_name" {


### PR DESCRIPTION
The `new_relic_enabled` flag did not work with a boolean and needed to be a string