### PR TITLE
Change Route53 Record to Alias instead of CNAME

### DIFF
--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -35,9 +35,13 @@ resource "aws_alb_listener_rule" "survey_runner" {
 resource "aws_route53_record" "survey_runner" {
   zone_id = "${data.aws_route53_zone.dns_zone.id}"
   name    = "${var.env}-surveys.${var.dns_zone_name}"
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${data.aws_alb.eq.dns_name}"]
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_alb.eq.dns_name}"
+    zone_id                = "${data.aws_alb.eq.zone_id}"
+    evaluate_target_health = false
+  }
 }
 
 data "template_file" "survey_runner" {
@@ -64,7 +68,6 @@ data "template_file" "survey_runner" {
     EQ_NEW_RELIC_ENABLED                 = "${var.new_relic_enabled}"
     NEW_RELIC_LICENSE_KEY                = "${var.new_relic_licence_key}"
     NEW_RELIC_APP_NAME                   = "${var.new_relic_app_name}"
-
   }
 }
 


### PR DESCRIPTION
Checks for resource record sets that can be changed to alias resource record sets to improve performance and save money. An alias resource record set routes DNS queries to an AWS resource (for example, an Elastic Load Balancing load balancer or an Amazon S3 bucket) or to another Route 53 resource record set. When you use alias resource record sets, Route 53 routes your DNS queries to AWS resources free of charge.

### How To Review
After deploying this branch with terraform
Survey runner should still be accessible via the url