### PR TITLE
Increase minimum number of ECS service containers

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -54,6 +54,11 @@ variable "survey_runner_min_tasks" {
   default     = "3"
 }
 
+variable "survey_runner_static_min_tasks" {
+  description = "The minimum number of Survey Runner Static tasks to run"
+  default     = "2"
+}
+
 variable "survey_runner_max_tasks" {
   description = "The Maximum number of Survey Runner tasks to run"
   default     = "50"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -101,7 +101,7 @@ resource "aws_ecs_service" "survey_runner" {
   }
 
   lifecycle {
-    ignore_changes = ["placement_strategy"]
+    ignore_changes = ["placement_strategy", "desired_count"]
   }
 }
 

--- a/survey_runner_static.tf
+++ b/survey_runner_static.tf
@@ -61,7 +61,7 @@ resource "aws_ecs_service" "survey_runner_static" {
   name            = "${var.env}-survey-runner-static"
   cluster         = "${data.aws_ecs_cluster.ecs-cluster.id}"
   task_definition = "${aws_ecs_task_definition.survey_runner_static.family}"
-  desired_count   = 1
+  desired_count   = "${var.survey_runner_static_min_tasks}"
   iam_role        = "${aws_iam_role.survey_runner_static.arn}"
 
   placement_strategy {
@@ -76,7 +76,7 @@ resource "aws_ecs_service" "survey_runner_static" {
   }
 
   lifecycle {
-    ignore_changes = ["placement_strategy"]
+    ignore_changes = ["placement_strategy", "desired_count"]
   }
 }
 


### PR DESCRIPTION
Services with a single container running may experience downtime on a ECS cluster scale down.
By increasing the number to higher than 1 for PreProd and Prod then the service will not experience outage when the cluster scales back

We should also ignore changes for the desired_count. This means that if terraform is run when the environment has scaled then it wont be scaled back down by terraform
lifecycle { ignore_changes = ["desired_count"] }
https://github.com/hashicorp/terraform/issues/4950